### PR TITLE
Création de l'entité Marque, du repository et de tests

### DIFF
--- a/migrations/Version20250103195911.php
+++ b/migrations/Version20250103195911.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250103195911 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE marque (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, slug VARCHAR(255) DEFAULT NULL, description LONGTEXT DEFAULT NULL, logo VARCHAR(255) DEFAULT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', is_active TINYINT(1) NOT NULL, UNIQUE INDEX UNIQ_5A6F91CE6C6E55B5 (nom), UNIQUE INDEX UNIQ_5A6F91CE989D9B62 (slug), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');;
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE marque');
+    }
+}

--- a/src/Entity/Marque.php
+++ b/src/Entity/Marque.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\MarqueRepository;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: MarqueRepository::class)]
+class Marque
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, unique: true)]
+    private ?string $nom = null;
+
+    #[ORM\Column(length: 255, nullable: true, unique: true)]
+    private ?string $slug = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $logo = null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    #[ORM\Column]
+    private ?bool $isActive = true;
+
+    public function __construct()
+    {
+
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getNom(): ?string
+    {
+        return $this->nom;
+    }
+
+    public function setNom(string $nom): static
+    {
+        $this->nom = $nom;
+
+        return $this;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(?string $slug): static
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getLogo(): ?string
+    {
+        return $this->logo;
+    }
+
+    public function setLogo(?string $logo): static
+    {
+        $this->logo = $logo;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTimeImmutable $updatedAt): static
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function isActive(): ?bool
+    {
+        return $this->isActive;
+    }
+
+    public function setActive(bool $isActive): static
+    {
+        $this->isActive = $isActive;
+
+        return $this;
+    }
+}

--- a/src/Repository/MarqueRepository.php
+++ b/src/Repository/MarqueRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Marque;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Marque>
+ */
+class MarqueRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Marque::class);
+    }
+
+    //    /**
+    //     * @return Marque[] Returns an array of Marque objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('m')
+    //            ->andWhere('m.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('m.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?Marque
+    //    {
+    //        return $this->createQueryBuilder('m')
+    //            ->andWhere('m.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}

--- a/tests/MarqueKernelTest.php
+++ b/tests/MarqueKernelTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Marque;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class MarqueKernelTest extends KernelTestCase
+{
+
+    public function testSomething(): void
+    {
+        $kernel = self::bootKernel();
+
+        // $container = self::$container;;
+        $validator = self::getContainer()->get(ValidatorInterface::class);
+
+        $marque = new Marque();
+        $marque->setNom('');
+        // $errors = $validator->validate($marque);
+        // $this->assertCount(1, $errors);
+        $this->expectExceptionMessage("Le nom ne peux être vide.");
+
+        // $routerService = static::getContainer()->get('router');
+        // $myCustomService = static::getContainer()->get(CustomService::class);
+    }
+}

--- a/tests/MarqueTest.php
+++ b/tests/MarqueTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Marque;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class MarqueTest extends TestCase
+{
+    public function testSetterAndGetterNotFail(): void
+    {
+        $marque = new Marque();
+        $marque->setNom("Jardin Nature");
+        $marque->setSlug("jardin et nature");
+        $marque->setDescription("Description pour Jardin Nature.");
+        $marque->setLogo("logo_jardin_nature.jpeg");
+        $marque->setCreatedAt(new DateTimeImmutable());
+        $this->assertEquals("Jardin Nature", $marque->getNom());
+        $this->assertEquals("jardin et nature", $marque->getSlug());
+        $this->assertEquals("Description pour Jardin Nature.", $marque->getDescription());
+        $this->assertEquals("logo_jardin_nature.jpeg", $marque->getLogo());
+        $this->assertTrue(true);
+    }
+    public function testSetterAndGetterFail(): void
+    {
+        $marque = new Marque();
+        $marque->setNom("");
+        // Ne pas appeler les setters pour tester si les valeurs par défaut ou les exceptions fonctionnent correctement
+
+        try {
+            $marque->getNom();
+        } catch (\Exception $e) {
+            $this->assertEquals('Nom obligatoire', $e->getMessage());
+        }
+
+        try {
+            $marque->getSlug();
+        } catch (\Exception $e) {
+            $this->assertEquals('Slug obligatoire', $e->getMessage());
+        }
+
+        try {
+            $marque->getDescription();
+        } catch (\Exception $e) {
+            $this->assertEquals('Description obligatoire', $e->getMessage());
+        }
+
+        try {
+            $marque->getLogo();
+        } catch (\Exception $e) {
+            $this->assertEquals('Logo obligatoire', $e->getMessage());
+        }
+
+        try {
+            $marque->getCreatedAt();
+        } catch (\Exception $e) {
+            $this->assertEquals('Date de création obligatoire', $e->getMessage());
+        }
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Cette pull request ajoute une nouvelle entité `Marque` au projet. Permet d'ajouter de façon flexible l'information de la marque d'un produit. 

###  Changements
- Ajout de l'entité `Marque` dans le répertoire *src/Entity*
- Création des propriétés cités dans #62 , #65 pour préparer la mise en place de l'entité `Produit`
- Pour l'implémentation de la gestion des Produits ( avec les catégories et les marques ) la propriété `slug` , `description` et `logo` peuvent être nullable.
- Génération via Doctrine : MarqueRepository associé à l'entité
- Génération du fichier de migration pour ajouter la table au schéma dans la base de données. 

### Structure de la table 
![image](https://github.com/user-attachments/assets/ccf7a3f1-12e0-4dc8-9922-6dfc5f329dc4)
