### PR TITLE
Changement apporté lors de l'implémentation de la fonctionnalité Catégorie.

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,39 +1,40 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Raleway:ital,wght@0,100..900;1,100..900&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-
 /*Composants front*/
-@import './components/buttons.css';
-@import './components/input_text.css';
+@import "./components/buttons.css";
+@import "./components/input_text.css";
 
 body {
-    font-family: Poppins;
-    /* font-family: Raleway; */
+  font-family: Poppins;
+  /* font-family: Raleway; */
 }
-
 
 h1,
 h2 {
-    font-family: Raleway;
+  font-family: Raleway;
 }
 
-
 h1 {
-    font-size: 2rem;
-    font-weight: 700;
+  font-size: 2rem;
+  font-weight: 700;
 }
 
 h2 {
-    font-size: 1.75rem;
-    font-weight: 600;
+  font-size: 1.75rem;
+  font-weight: 600;
 }
 
-input[type=text],
-input[type=email],
-input[type=password] {
- @apply border-b-2 rounded-t-sm focus-visible:bg-secondary-light focus:border-b  focus:!outline-none focus-visible:border-b-2 focus-visible:border-secondary-dark focus:border-transparent focus:placeholder:bg-secondary-light focus:placeholder:border-none hover:placeholder-shown:bg-secondary-light border-secondary-dark text-sm placeholder-secondary-dark h-8;
+input[type="text"],
+input[type="email"],
+input[type="password"] {
+  @apply border-b-2 rounded-t-sm focus-visible:bg-secondary-light focus:border-b  focus:!outline-none focus-visible:border-b-2 focus-visible:border-secondary-dark focus:border-transparent focus:placeholder:bg-secondary-light focus:placeholder:border-none hover:placeholder-shown:bg-secondary-light border-secondary-dark text-sm placeholder-secondary-dark h-8;
+}
+
+textarea {
+  @apply border-b-2 rounded-t-sm focus-visible:bg-secondary-light focus:border-b  focus:!outline-none focus-visible:border-b-2 focus-visible:border-secondary-dark focus:border-transparent focus:placeholder:bg-secondary-light focus:placeholder:border-none hover:placeholder-shown:bg-secondary-light border-secondary-dark text-sm placeholder-secondary-dark;
 }
 
 /* .text-secondary {
@@ -72,7 +73,6 @@ body {
     color: #4CAF50;
 }
  */
-
 
 /* .container .banner-div {
     background-color: #795548;
@@ -115,7 +115,8 @@ body {
 } */
 
 .shadow-bottom {
-    box-shadow: 0 4px 6px -1px rgba(151, 151, 151, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 4px 6px -1px rgba(151, 151, 151, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 
 /* 

--- a/migrations/Version20250108123050.php
+++ b/migrations/Version20250108123050.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250108123050 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE categorie CHANGE slug slug VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE categorie CHANGE slug slug VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/src/Controller/CategorieController.php
+++ b/src/Controller/CategorieController.php
@@ -14,9 +14,12 @@ use Symfony\Component\Routing\Attribute\Route;
 // #[Route('/categorie')]
 final class CategorieController extends AbstractController
 {
-    #[Route('/categorie', name: 'app_categorie_index', methods: ['GET'])]
+    #[Route('admin/categorie', name: 'app_categorie_index', methods: ['GET'])]
     public function index(CategorieRepository $categorieRepository): Response
     {
+        if (!$this->isGranted('ROLE_ADMIN')) { // Redirige vers la route de la page d'accueil 
+            return $this->redirectToRoute('app_main');
+        }
         return $this->render('categorie/index.html.twig', [
             'categories' => $categorieRepository->findAll(),
         ]);
@@ -25,6 +28,9 @@ final class CategorieController extends AbstractController
     #[Route('/admin/categorie/new', name: 'app_categorie_new', methods: ['GET', 'POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): Response
     {
+        if (!$this->isGranted('ROLE_ADMIN')) { // Redirige vers la route de la page d'accueil 
+            return $this->redirectToRoute('app_main');
+        }
         $categorie = new Categorie();
         $form = $this->createForm(CategorieType::class, $categorie);
         $form->handleRequest($request);
@@ -45,7 +51,6 @@ final class CategorieController extends AbstractController
     #[Route('/categorie/{id}', name: 'app_categorie_show', methods: ['GET'])]
     public function show(Categorie $categorie): Response
     {
-
         return $this->render('categorie/show.html.twig', [
             'categorie' => $categorie,
         ]);
@@ -54,6 +59,9 @@ final class CategorieController extends AbstractController
     #[Route('/admin/categorie/{id}/edit', name: 'app_categorie_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, Categorie $categorie, EntityManagerInterface $entityManager): Response
     {
+        if (!$this->isGranted('ROLE_ADMIN')) { // Redirige vers la route de la page d'accueil 
+            return $this->redirectToRoute('app_main');
+        }
         $form = $this->createForm(CategorieType::class, $categorie);
         $form->handleRequest($request);
 
@@ -72,6 +80,9 @@ final class CategorieController extends AbstractController
     #[Route('/admin/categorie/{id}', name: 'app_categorie_delete', methods: ['POST'])]
     public function delete(Request $request, Categorie $categorie, EntityManagerInterface $entityManager): Response
     {
+        if (!$this->isGranted('ROLE_ADMIN')) { // Redirige vers la route de la page d'accueil 
+            return $this->redirectToRoute('app_main');
+        }
         if ($this->isCsrfTokenValid('delete' . $categorie->getId(), $request->getPayload()->getString('_token'))) {
             $entityManager->remove($categorie);
             $entityManager->flush();

--- a/src/Controller/CategorieController.php
+++ b/src/Controller/CategorieController.php
@@ -6,10 +6,12 @@ use App\Entity\Categorie;
 use App\Form\CategorieType;
 use App\Repository\CategorieRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 // #[Route('/categorie')]
 final class CategorieController extends AbstractController
@@ -26,7 +28,7 @@ final class CategorieController extends AbstractController
     }
 
     #[Route('/admin/categorie/new', name: 'app_categorie_new', methods: ['GET', 'POST'])]
-    public function new(Request $request, EntityManagerInterface $entityManager): Response
+    public function new(Request $request, EntityManagerInterface $entityManager,  SluggerInterface $slugger): Response
     {
         if (!$this->isGranted('ROLE_ADMIN')) { // Redirige vers la route de la page d'accueil 
             return $this->redirectToRoute('app_main');
@@ -36,6 +38,9 @@ final class CategorieController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $slugCategorie = $slugger->slug($categorie->getNom());
+            // dump($slugCategorie);
+            $categorie->setSlug(strtolower($slugCategorie));
             $entityManager->persist($categorie);
             $entityManager->flush();
 
@@ -48,16 +53,22 @@ final class CategorieController extends AbstractController
         ]);
     }
 
-    #[Route('/categorie/{id}', name: 'app_categorie_show', methods: ['GET'])]
-    public function show(Categorie $categorie): Response
+    // #[Route('/categorie/{id}', name: 'app_categorie_show', methods: ['GET'])]
+    #[Route('/categorie/{slug}', name: 'app_categorie_show', methods: ['GET'])]
+    public function show(#[MapEntity(mapping: ['slug' => "slug"])] Categorie $categorie, SluggerInterface $slugger): Response
     {
+        // $slugCategorie = $slugger->slug($categorie->getNom());
+        // $categorie->setSlug(strtolower($slugCategorie));
+        // dump($slugCategorie);
+        // dd($categorie);
+
         return $this->render('categorie/show.html.twig', [
             'categorie' => $categorie,
         ]);
     }
 
-    #[Route('/admin/categorie/{id}/edit', name: 'app_categorie_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, Categorie $categorie, EntityManagerInterface $entityManager): Response
+    #[Route('/admin/categorie/{slug}/edit', name: 'app_categorie_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, #[MapEntity(mapping: ['slug' => "slug"])] Categorie $categorie, EntityManagerInterface $entityManager): Response
     {
         if (!$this->isGranted('ROLE_ADMIN')) { // Redirige vers la route de la page d'accueil 
             return $this->redirectToRoute('app_main');

--- a/src/Entity/Categorie.php
+++ b/src/Entity/Categorie.php
@@ -20,7 +20,7 @@ class Categorie
     #[ORM\Column(length: 255)]
     private ?string $nom = null;
 
-    #[ORM\Column(length: 255, nullable: true, unique: true)]
+    #[ORM\Column(length: 255, unique: true)]
     private ?string $slug = null;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]

--- a/src/Form/CategorieType.php
+++ b/src/Form/CategorieType.php
@@ -5,18 +5,77 @@ namespace App\Form;
 use App\Entity\Categorie;
 use App\Entity\Produit;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class CategorieType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('nom')
-            ->add('slug')
-            ->add('description')
+            ->add('nom', TextType::class, [
+                'label' => 'Nom de la catégorie :',
+                'constraints' => [
+                    new NotBlank([
+                        'message' => "Le nom de la catégorie ne peut pas être vide."
+                    ]),
+                    new Length([
+                        'min' => 2,
+                        'max' => 255,
+                        'minMessage' => "Le nom de la catégorie doit être au moins de 3.",
+                        'maxMessage' => "Le nom de la catégorie est trop grand. (max 255)"
+                    ]),
+                ],
+                'attr' => [
+                    'maxLength' => 255,
+                    'placeholder' => "Insérer nom de la catégorie",
+                ]
+            ])
+            ->add('slug', TextType::class, [
+                'label' => 'Slug à afficher :',
+                'required' => false,
+                'constraints' => [
+                    new Length([
+                        'max' => 255,
+                        'maxMessage' => "Le slug de la catégorie est trop grand. (max 255)"
+                    ]),
+                ],
+                'attr' => [
+                    'maxLength' => 255,
+                    'placeholder' => "Slug pour l'URL",
+                ]
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'Description de la catégorie :',
+                'required' => false,
+                'constraints' => [
+                    new Length([
+                        'min' => 50,
+                        'minMessage' => "La description de la catégorie doit faire plus de 50 caractères",
+                        'max' => 500,
+                        'maxMessage' => "La description de la catégorie est trop grand. (max 500)"
+                    ]),
+                    new Regex([
+                        'pattern' => '/^[a-zA-Z0-9\s\p{L}\p{P}]+$/u',
+                        'message' => "Ce champ contient des caractères non autorisés pour une description",
+                    ])
+                ],
+                'attr' => [
+
+                    'rows' => 5,
+                    'cols' => 50,
+                    'minLength' => 50,
+                    'maxLength' => 500,
+                    'placeholder' => "Décrire la catégorie, sera affiché à l'utilisateur",
+                ]
+            ])
             // ->add('createdAt', null, [
             //     'widget' => 'single_text',
             // ])
@@ -36,6 +95,12 @@ class CategorieType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Categorie::class,
+            'csrf_protection' => true,
+            // the name of the hidden HTML field that stores the token
+            'csrf_field_name' => '_token',
+            // an arbitrary string used to generate the value of the token
+            // using a different string for each form improves its security
+            'csrf_token_id'   => 'categorie_item',
         ]);
     }
 }

--- a/src/Form/CategorieType.php
+++ b/src/Form/CategorieType.php
@@ -29,7 +29,7 @@ class CategorieType extends AbstractType
                     new Length([
                         'min' => 2,
                         'max' => 255,
-                        'minMessage' => "Le nom de la catégorie doit être au moins de 3.",
+                        'minMessage' => "Le nom de la catégorie doit être au moins de 2.",
                         'maxMessage' => "Le nom de la catégorie est trop grand. (max 255)"
                     ]),
                 ],
@@ -38,20 +38,20 @@ class CategorieType extends AbstractType
                     'placeholder' => "Insérer nom de la catégorie",
                 ]
             ])
-            ->add('slug', TextType::class, [
-                'label' => 'Slug à afficher :',
-                'required' => false,
-                'constraints' => [
-                    new Length([
-                        'max' => 255,
-                        'maxMessage' => "Le slug de la catégorie est trop grand. (max 255)"
-                    ]),
-                ],
-                'attr' => [
-                    'maxLength' => 255,
-                    'placeholder' => "Slug pour l'URL",
-                ]
-            ])
+            // ->add('slug', TextType::class, [
+            //     'label' => 'Slug à afficher :',
+            //     'required' => false,
+            //     'constraints' => [
+            //         new Length([
+            //             'max' => 255,
+            //             'maxMessage' => "Le slug de la catégorie est trop grand. (max 255)"
+            //         ]),
+            //     ],
+            //     'attr' => [
+            //         'maxLength' => 255,
+            //         'placeholder' => "Slug pour l'URL",
+            //     ]
+            // ])
             ->add('description', TextareaType::class, [
                 'label' => 'Description de la catégorie :',
                 'required' => false,

--- a/templates/_partials/_navbar.html.twig
+++ b/templates/_partials/_navbar.html.twig
@@ -26,7 +26,8 @@
 
 			<ul class=" absolute hidden bg-light-default p-5 border-radius-2 rounded-xl shadow-[0_2px_4px_-2px_rgba(0,0,0,0.3)]" id="category-navbar">
 				{% for categorie in categories %}
-					<a href=" {{path('app_categorie_show', {'id': categorie.id})}} ">
+					{# <a href=" {{path('app_categorie_show', {'id': categorie.id})}} "> #}
+					<a href=" {{path('app_categorie_show', {'slug': categorie.slug})}} ">
 						<li class=" text-tertiary-darker hover:text-primary-default">
 							{{categorie.nom}}</li>
 					</a>
@@ -123,7 +124,7 @@
 						<div class=" hidden mt-2 space-y-2" id="list-menu">
 							<ul>
 								{% for categorie in categories %}
-									<a href=" {{path('app_categorie_show', {'id': categorie.id})}} ">
+									<a href=" {{path('app_categorie_show', {'slug': categorie.slug})}} ">
 										<li class=" text-tertiary-darker hover:text-primary-default">
 											{{categorie.nom}}</li>
 									</a>

--- a/templates/categorie/_form.html.twig
+++ b/templates/categorie/_form.html.twig
@@ -2,8 +2,8 @@
 <div class="flex flex-col w-[20rem] ">
     {{form_label(form.nom)}}
 	{{ form_widget(form.nom) }}
-    {{form_label(form.slug)}}
-	{{ form_widget(form.slug) }}
+    {# {{form_label(form.slug)}}
+	{{ form_widget(form.slug) }} #}
     {{form_label(form.description)}}
 	{{ form_widget(form.description) }}
 </div>

--- a/templates/categorie/_form.html.twig
+++ b/templates/categorie/_form.html.twig
@@ -1,4 +1,11 @@
 {{ form_start(form) }}
-    {{ form_widget(form) }}
+<div class="flex flex-col w-[20rem] ">
+    {{form_label(form.nom)}}
+	{{ form_widget(form.nom) }}
+    {{form_label(form.slug)}}
+	{{ form_widget(form.slug) }}
+    {{form_label(form.description)}}
+	{{ form_widget(form.description) }}
+</div>
     <button class="btn">{{ button_label|default('Save') }}</button>
 {{ form_end(form) }}

--- a/templates/categorie/index.html.twig
+++ b/templates/categorie/index.html.twig
@@ -29,8 +29,8 @@
                 <td>{{ categorie.updatedAt ? categorie.updatedAt|date('Y-m-d H:i:s') : '' }}</td>
                 <td>{{ categorie.isVisible ? 'Yes' : 'No' }}</td>
                 <td>
-                    <a href="{{ path('app_categorie_show', {'id': categorie.id}) }}">show</a>
-                    <a href="{{ path('app_categorie_edit', {'id': categorie.id}) }}">edit</a>
+                    <a href="{{ path('app_categorie_show', {'slug': categorie.slug}) }}">show</a>
+                    <a href="{{ path('app_categorie_edit', {'slug': categorie.slug}) }}">edit</a>
                 </td>
             </tr>
         {% else %}

--- a/templates/categorie/new.html.twig
+++ b/templates/categorie/new.html.twig
@@ -3,7 +3,7 @@
 {% block title %}New Categorie{% endblock %}
 
 {% block body %}
-    <h1>Create new Categorie</h1>
+    <h1>Nouvelle catégorie pour les produits</h1>
 
     {{ include('categorie/_form.html.twig') }}
 

--- a/templates/categorie/show.html.twig
+++ b/templates/categorie/show.html.twig
@@ -65,7 +65,7 @@
 	
 		<a href="{{ path('app_categorie_index') }}">back to list</a>
 
-		<a href="{{ path('app_categorie_edit', {'id': categorie.id}) }}">edit</a>
+		<a href="{{ path('app_categorie_edit', {'slug': categorie.slug}) }}">edit</a>
 
 		{{ include('categorie/_delete_form.html.twig') }}
 	{% endif %}

--- a/templates/categorie/show.html.twig
+++ b/templates/categorie/show.html.twig
@@ -9,7 +9,7 @@
 	<table class="table">
 		<tbody>
 
-			{% if 'ROLE_ADMIN' in app.user.roles %}
+			{% if is_granted("ROLE_ADMIN") %}
 				<tr>
 					<th>Id</th>
 					<td>{{ categorie.id }}</td>
@@ -19,7 +19,7 @@
 				<th>Nom</th>
 				<td>{{ categorie.nom }}</td>
 			</tr>
-			{% if 'ROLE_ADMIN' in app.user.roles %}
+			{% if is_granted("ROLE_ADMIN") %}
 				<tr>
 					<th>Slug</th>
 					<td>{{ categorie.slug }}</td>
@@ -27,9 +27,10 @@
 			{% endif %}
 			<tr>
 				<th>Description</th>
-				<td>{{ categorie.description }}</td>
+				<td>{{ categorie.description|e }}</td>
 			</tr>
-			{% if 'ROLE_ADMIN' in app.user.roles %}
+			
+			{% if is_granted("ROLE_ADMIN") %}
 				<tr>
 					<th>CreatedAt</th>
 					<td>{{ categorie.createdAt ? categorie.createdAt|date('Y-m-d H:i:s') : '' }}</td>
@@ -41,7 +42,7 @@
 			{% endif %}
 
 
-			{% if 'ROLE_ADMIN' in app.user.roles %}
+			{% if is_granted("ROLE_ADMIN") %}
 				<tr>
 					<th>IsVisible</th>
 					<td>{{ categorie.isVisible ? 'Yes' : 'No' }}</td>
@@ -60,7 +61,8 @@
 		{% endfor %}
 	{% endif %}
 
-	{% if 'ROLE_ADMIN' in app.user.roles %}
+			{% if is_granted("ROLE_ADMIN") %}
+	
 		<a href="{{ path('app_categorie_index') }}">back to list</a>
 
 		<a href="{{ path('app_categorie_edit', {'id': categorie.id}) }}">edit</a>


### PR DESCRIPTION
PR qui résume tout ce que j'ai implémenté et/ou modifié dans les fichiers pour la gestion et l'affichage des **catégories**. 

### CategorieController.php

Changement des routes pour certaines méthodes ( *index, new, edit, delete* ) pour un affichage dans le back-office (admin/)

- `index` : Affiche toutes les catégories.
- `new` : Crée une nouvelle catégorie. Génération du `slug` à partir du nom donné.
- `edit` :  modification d'une catégorie : 
  - si le formulaire est soumis et valide, le slug est mis à jour si le nom a changé.
  - Création d'une nouvelle instance pour la propriété `updatedAt`. 
- `delete` : Supprime la catégorie liée à l'ID. 

Ces quatre méthodes sont accessibles uniquement aux utilisateurs ayant au moins `ROLE_ADMIN`. 
Si l'utilisateur n'a que le ROLE_USER ou n'est pas connecté, il est redirigé à la page d'accueil. 

- `show` : affichage des catégorie ( mappé par le slug ).  
  - Affichage granulaire en fonction des droits d'utilisateur. Les utilisateurs avec le `ROLE_USER` et les utilisateurs non connectés  voient uniquement le `nom` et la `description` des catégories.  

### Categorie.php 
A présent que le slug est configuré et fonctionnel, il ne peut plus être nullable 
- `nullable = true` a été effacé.

- Création d'un fichier de migration pour mettre à jour le schéma de la table `Catégorie` pour la propriété `slug`. 

C'est pour cette raison que la propriété `nom` est unique, pour garantir l'unicité de chaque enregistrement présent dans `slug`. 

### CategorieType.php

- Implémentation détaillée du formulaire liée à l'entité `Categorie`
- Création des messages à afficher si le champs obligatoire est vide ou si les validations ne sont pas correctes. 
- Mise en place du token *CSRF* 

 #### Les champs qui s'affichent lors de la création ou bien lors de la modification d'une *catégorie*  : 
- `nom` : champ requis et unique 
- `description` : optionnel

## Templates 
### templates/_partials/_navbar 
- remplacer `categorie.id` -> `categorie.slug`

### templates/categorie/index.html.twig
- remplacer les boutons/liens de navigation :  
`categorie.id` => `categorie.slug`

### templates/categorie/new.html.twig 
- changement du titre

### temapltes/categorie/show.html.twig
- changement des conditions pour l'affichage en fonction des droits utilisateurs.

### app.css
- ajout du style pour les tag `textarea`


 